### PR TITLE
automatically run build after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "packages/boilerplate-angular"
     ],
     "scripts": {
+        "postinstall": "yarn build",
         "clean": "./scripts/clean.sh",
         "start:react": "yarn workspace @telements/boilerplate-react start",
         "start:next": "yarn workspace @telements/boilerplate-next start",


### PR DESCRIPTION
This feature should enhance the development flow. After `yarn` the `build` command is executed automatically, so the dependent `packages` have their artefacts and are ready to start