### PR TITLE
fix: auto generate docs for existing components

### DIFF
--- a/packages/components/src/components/alert/readme.md
+++ b/packages/components/src/components/alert/readme.md
@@ -35,12 +35,35 @@ Type: `Promise<void>`
 
 ## CSS Custom Properties
 
-| Name                        | Description                    |
-| --------------------------- | ------------------------------ |
-| `--alert-color`             | Color of the button            |
-| `--button-background-color` | Background color of the button |
-| `--button-border`           | Border of the button           |
-| `--button-border-color`     | Border color of the button     |
+| Name                                   | Description                                      |
+| -------------------------------------- | ------------------------------------------------ |
+| `--alert-background`                   | Background color of the alert                    |
+| `--alert-close-height`                 | Height of the close icon of the alert            |
+| `--alert-close-hover-opacity`          | Hover opacity of the close icon of the alert     |
+| `--alert-close-opacity`                | Opacity of the close icon of the alert           |
+| `--alert-close-width`                  | Width of the close icon of the alert             |
+| `--alert-color`                        | Color of the text of the alert                   |
+| `--alert-icon-background`              | Background color of the icon of the alert        |
+| `--alert-icon-border-radius`           | Border radius of the icon of the alert           |
+| `--alert-icon-height`                  | Height of the icon of the alert                  |
+| `--alert-icon-margin`                  | Margin of the icon of the alert                  |
+| `--alert-icon-width`                   | Width of the icon of the alert                   |
+| `--alert-padding`                      | Padding of the alert                             |
+| `--alert-title-color`                  | Color of the title of the alert                  |
+| `--alert-title-font-size`              | Font size of the title of the alert              |
+| `--alert-title-margin`                 | Margin of the title of the alert                 |
+| `--alert-variant-danger-background`    | Background color of the variant danger alert     |
+| `--alert-variant-danger-color`         | Color of the text of the variant danger alert    |
+| `--alert-variant-info-background`      | Background color of the variant info alert       |
+| `--alert-variant-info-color`           | Color of the text of the variant info alert      |
+| `--alert-variant-primary-background`   | Background color of the variant primary alert    |
+| `--alert-variant-primary-color`        | Color of the text the variant primary alert      |
+| `--alert-variant-secondary-background` | Background color of the variant secondary alert  |
+| `--alert-variant-secondary-color`      | Color of the text of the variant secondary alert |
+| `--alert-variant-success-background`   | Background color of the variant success alert    |
+| `--alert-variant-success-color`        | Color of the text of the variant success alert   |
+| `--alert-variant-warning-background`   | Background color of the variant warning alert    |
+| `--alert-variant-warning-color`        | Color of the text of the variant warning alert   |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/card/readme.md
+++ b/packages/components/src/components/card/readme.md
@@ -7,13 +7,15 @@
 
 ## Properties
 
-| Property     | Attribute    | Description | Type      | Default |
-| ------------ | ------------ | ----------- | --------- | ------- |
-| `deselected` | `deselected` |             | `boolean` | `false` |
-| `disabled`   | `disabled`   |             | `boolean` | `false` |
-| `size`       | `size`       |             | `string`  | `''`    |
-| `theme`      | `theme`      |             | `string`  | `''`    |
-| `variant`    | `variant`    |             | `string`  | `''`    |
+| Property      | Attribute       | Description | Type      | Default     |
+| ------------- | --------------- | ----------- | --------- | ----------- |
+| `deselected`  | `deselected`    |             | `boolean` | `false`     |
+| `disabled`    | `disabled`      |             | `boolean` | `false`     |
+| `imageTop`    | `image-top`     |             | `string`  | `undefined` |
+| `imageTopAlt` | `image-top-alt` |             | `string`  | `''`        |
+| `size`        | `size`          |             | `string`  | `''`        |
+| `theme`       | `theme`         |             | `string`  | `''`        |
+| `variant`     | `variant`       |             | `string`  | `''`        |
 
 
 ----------------------------------------------

--- a/packages/components/src/components/input-text/readme.md
+++ b/packages/components/src/components/input-text/readme.md
@@ -1,0 +1,10 @@
+# t-input-text
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
Run `yarn build` to generate missing docs by stencil.js