### PR TITLE
feature: add documentation site (jekyll) to showcase component examples

### DIFF
--- a/packages/components/docs/.gitignore
+++ b/packages/components/docs/.gitignore
@@ -1,0 +1,5 @@
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor

--- a/packages/components/docs/Gemfile
+++ b/packages/components/docs/Gemfile
@@ -1,0 +1,30 @@
+source "https://rubygems.org"
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 4.0.0"
+# This is the default theme for new Jekyll sites. You may change this to anything you like.
+gem "minima", "~> 2.5"
+# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# uncomment the line below. To upgrade, run `bundle update github-pages`.
+# gem "github-pages", group: :jekyll_plugins
+# If you have any plugins, put them here!
+group :jekyll_plugins do
+  gem "jekyll-feed", "~> 0.12"
+end
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+install_if -> { RUBY_PLATFORM =~ %r!mingw|mswin|java! } do
+  gem "tzinfo", "~> 1.2"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
+

--- a/packages/components/docs/_config.yml
+++ b/packages/components/docs/_config.yml
@@ -1,0 +1,53 @@
+# Welcome to Jekyll!
+#
+# This config file is meant for settings that affect your whole blog, values
+# which you are expected to set up once and rarely edit after that. If you find
+# yourself editing this file very often, consider using Jekyll's data files
+# feature for the data you need to update frequently.
+#
+# For technical reasons, this file is *NOT* reloaded automatically when you use
+# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
+#
+# If you need help with YAML syntax, here are some quick references for you:
+# https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
+# https://learnxinyminutes.com/docs/yaml/
+#
+# Site settings
+# These are used to personalize your new site. If you look in the HTML files,
+# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
+# You can create any custom variable you would like, and they will be accessible
+# in the templates via {{ site.myvariable }}.
+
+title: Telements
+email: egor.kirpichev@telekom.de
+description: >- # this means to ignore newlines until "baseurl:"
+  The Telements library offers a set of customizable UI components written with
+  Stencil.js & TypeScript. The default theme of the library can be easily replaced
+  so that a corresponding corporate identity of a dedicated brand can be represented.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed
+
+# Exclude from processing.
+# The following items will not be processed, by default.
+# Any item listed under the `exclude:` key here will be automatically added to
+# the internal "default list".
+#
+# Excluded items can be processed by explicitly listing the directories or
+# their entries' file path in the `include:` list.
+#
+# exclude:
+#   - .sass-cache/
+#   - .jekyll-cache/
+#   - gemfiles/
+#   - Gemfile
+#   - Gemfile.lock
+#   - node_modules/
+#   - vendor/bundle/
+#   - vendor/cache/
+#   - vendor/gems/
+#   - vendor/ruby/

--- a/packages/components/docs/_includes/head.html
+++ b/packages/components/docs/_includes/head.html
@@ -1,0 +1,13 @@
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	{%- seo -%}
+	<link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+	{%- feed_meta -%}
+	{%- if jekyll.environment == 'production' and site.google_analytics -%}
+		{%- include google-analytics.html -%}
+	{%- endif -%}
+	<script type="module" src="{{ '/dist/telements-components.esm.js' | relative_url }}"></script>
+  <script nomodule src="{{ '/dist/telements-components.js' | relative_url }}"></script>
+</head>

--- a/packages/components/docs/_includes/header.html
+++ b/packages/components/docs/_includes/header.html
@@ -1,0 +1,24 @@
+<header class="sidebar">
+
+  <div class="sidebar__container">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign pages = site.header_pages | default: default_paths -%}
+    {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
+    <div class="sidebar__header">
+      <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    </div>
+
+    {%- if titles_size > 0 -%}
+      <nav class="site-nav">
+        {%- for path in pages -%}
+          {%- assign page = site.pages | where: "path", path | first -%}
+          {% unless page.exclude %}
+            {%- if page.title -%}
+              <a class="site-nav__item" href="{{ page.url | relative_url }}">{{ page.title | escape }}</a>
+            {%- endif -%}
+          {% endunless %}
+        {%- endfor -%}
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/packages/components/docs/_layouts/default.html
+++ b/packages/components/docs/_layouts/default.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: " en-US " }}">
+
+{%- include head.html -%}
+
+<body>
+  <div class="layout">
+    {%- include header.html -%}
+
+    <section class="site-content">
+      <div class="site-content__container">
+        {{ content }}
+      </div>
+    </section>
+  </div>
+
+  <!-- {% if site.google_analytics %}
+  <script type="text/javascript">
+    (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+    })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+
+    ga('create', '{{ site.google_analytics }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+  {% endif %} -->
+</body>
+
+</html>

--- a/packages/components/docs/_sass/minima.scss
+++ b/packages/components/docs/_sass/minima.scss
@@ -1,0 +1,56 @@
+@charset "utf-8";
+
+// Define defaults for each variable.
+
+$base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$base-font-size:   16px !default;
+$base-font-weight: 400 !default;
+$small-font-size:  $base-font-size * 0.875 !default;
+$base-line-height: 1.5 !default;
+
+$spacing-unit:     30px !default;
+
+$text-color:       #111 !default;
+$background-color: #fdfdfd !default;
+$brand-color:      #2a7ae2 !default;
+
+$grey-color:       #828282 !default;
+$grey-color-light: lighten($grey-color, 40%) !default;
+$grey-color-dark:  darken($grey-color, 25%) !default;
+$orange-color:     #f66a0a !default;
+$table-text-align: left !default;
+
+// Width of the content area
+$content-width:    800px !default;
+
+$on-palm:          600px !default;
+$on-laptop:        800px !default;
+
+$on-medium:        $on-palm !default;
+$on-large:         $on-laptop !default;
+
+// Use media queries like this:
+// @include media-query($on-palm) {
+//   .wrapper {
+//     padding-right: $spacing-unit / 2;
+//     padding-left: $spacing-unit / 2;
+//   }
+// }
+// Notice the following mixin uses max-width, in a deprecated, desktop-first
+// approach, whereas media queries used elsewhere now use min-width.
+@mixin media-query($device) {
+  @media screen and (max-width: $device) {
+    @content;
+  }
+}
+
+@mixin relative-font-size($ratio) {
+  font-size: $base-font-size * $ratio;
+}
+
+// Import partials.
+@import
+  "style/base",
+  "style/layout",
+  "style/syntax-highlighting"
+;

--- a/packages/components/docs/_sass/style/_base.scss
+++ b/packages/components/docs/_sass/style/_base.scss
@@ -1,0 +1,199 @@
+/**
+ * Reset some basic elements
+ */
+body, h1, h2, h3, h4, h5, h6,
+p, blockquote, pre, hr,
+dl, dd, ol, ul, figure {
+  margin: 0;
+  padding: 0;
+
+}
+
+
+
+/**
+ * Basic styling
+ */
+body {
+  font: $base-font-weight #{$base-font-size}/#{$base-line-height} $base-font-family;
+  color: $text-color;
+  background-color: $background-color;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-feature-settings: "kern" 1;
+     -moz-font-feature-settings: "kern" 1;
+       -o-font-feature-settings: "kern" 1;
+          font-feature-settings: "kern" 1;
+  font-kerning: normal;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+
+
+/**
+ * Set `margin-bottom` to maintain vertical rhythm
+ */
+h1, h2, h3, h4, h5, h6,
+p, blockquote, pre,
+ul, ol, dl, figure,
+%vertical-rhythm {
+  margin-bottom: $spacing-unit / 2;
+}
+
+
+
+/**
+ * `main` element
+ */
+main {
+  display: block; /* Default value of `display` of `main` element is 'inline' in IE 11. */
+}
+
+
+
+/**
+ * Images
+ */
+img {
+  max-width: 100%;
+  vertical-align: middle;
+}
+
+
+
+/**
+ * Figures
+ */
+figure > img {
+  display: block;
+}
+
+figcaption {
+  font-size: $small-font-size;
+}
+
+
+
+/**
+ * Lists
+ */
+ul, ol {
+  margin-left: $spacing-unit;
+}
+
+li {
+  > ul,
+  > ol {
+    margin-bottom: 0;
+  }
+}
+
+
+
+/**
+ * Headings
+ */
+h1, h2, h3, h4, h5, h6 {
+  font-weight: $base-font-weight;
+}
+
+
+
+/**
+ * Links
+ */
+a {
+  color: $brand-color;
+  text-decoration: none;
+
+  &:visited {
+    color: darken($brand-color, 15%);
+  }
+
+  &:hover {
+    color: $text-color;
+    text-decoration: underline;
+  }
+
+  .social-media-list &:hover {
+    text-decoration: none;
+
+    .username {
+      text-decoration: underline;
+    }
+  }
+}
+
+
+/**
+ * Blockquotes
+ */
+blockquote {
+  color: $grey-color;
+  border-left: 4px solid $grey-color-light;
+  padding-left: $spacing-unit / 2;
+  @include relative-font-size(1.125);
+  letter-spacing: -1px;
+  font-style: italic;
+
+  > :last-child {
+    margin-bottom: 0;
+  }
+}
+
+
+
+/**
+ * Code formatting
+ */
+pre,
+code {
+  @include relative-font-size(0.8);
+  border: 1px solid $grey-color-light;
+  border-radius: 3px;
+  background-color: #eef;
+}
+
+code {
+  padding: 1px 5px;
+}
+
+pre {
+  padding: 8px 12px;
+  overflow-x: auto;
+
+  > code {
+    border: 0;
+    padding-right: 0;
+    padding-left: 0;
+  }
+}
+
+/**
+ * Tables
+ */
+table {
+  margin-bottom: $spacing-unit;
+  width: 100%;
+  text-align: $table-text-align;
+  color: lighten($text-color, 18%);
+  border-collapse: collapse;
+  border: 1px solid $grey-color-light;
+  tr {
+    &:nth-child(even) {
+      background-color: lighten($grey-color-light, 6%);
+    }
+  }
+  th, td {
+    padding: ($spacing-unit / 3) ($spacing-unit / 2);
+  }
+  th {
+    background-color: lighten($grey-color-light, 3%);
+    border: 1px solid darken($grey-color-light, 4%);
+    border-bottom-color: darken($grey-color-light, 12%);
+  }
+  td {
+    border: 1px solid $grey-color-light;
+  }
+}

--- a/packages/components/docs/_sass/style/_layout.scss
+++ b/packages/components/docs/_sass/style/_layout.scss
@@ -1,0 +1,66 @@
+.layout {
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  overflow: hidden;
+}
+
+.sidebar {
+  height: 100%;
+  overflow-y: scroll;
+  width: 100%;
+  max-width: 240px;
+  flex: 1 0 auto;
+  border-right: 1px solid #ddd;
+
+  &__container {
+    padding: 1rem;
+  }
+
+  &__header {
+    padding: 1rem 0;
+  }
+}
+
+.site-title {
+  font-weight: bold;
+  margin: 0;
+}
+
+.site-nav {
+  display: flex;
+  flex-direction: column;
+}
+
+.site-content {
+  overflow-y: scroll;
+  width: 100%;
+  padding: 1rem;
+
+  &__container {
+    width: 100%;
+  }
+
+  h1 {
+    padding-top: 1rem;
+    font-weight: bold;
+  }
+
+  h2 {
+    margin-top: 2rem;
+    font-weight: bold;
+  }
+
+  h3 {
+    margin-top: 2rem;
+    font-weight: bold;
+  }
+}
+
+.demo-container {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}

--- a/packages/components/docs/_sass/style/_syntax-highlighting.scss
+++ b/packages/components/docs/_sass/style/_syntax-highlighting.scss
@@ -1,0 +1,75 @@
+/**
+ * Syntax highlighting styles
+ */
+.highlight {
+  background: rgb(248, 248, 248);
+  @extend %vertical-rhythm;
+
+  code {
+    background: none;
+  }
+
+  .highlighter-rouge & {
+    // background: rgb(238, 255, 242);
+  }
+
+  .c     { color: #998; font-style: italic } // Comment
+  .err   { color: #a61717; background-color: #e3d2d2 } // Error
+  .k     { font-weight: bold } // Keyword
+  .o     { font-weight: bold } // Operator
+  .cm    { color: #998; font-style: italic } // Comment.Multiline
+  .cp    { color: #999; font-weight: bold } // Comment.Preproc
+  .c1    { color: #998; font-style: italic } // Comment.Single
+  .cs    { color: #999; font-weight: bold; font-style: italic } // Comment.Special
+  .gd    { color: #000; background-color: #fdd } // Generic.Deleted
+  .gd .x { color: #000; background-color: #faa } // Generic.Deleted.Specific
+  .ge    { font-style: italic } // Generic.Emph
+  .gr    { color: #a00 } // Generic.Error
+  .gh    { color: #999 } // Generic.Heading
+  .gi    { color: #000; background-color: #dfd } // Generic.Inserted
+  .gi .x { color: #000; background-color: #afa } // Generic.Inserted.Specific
+  .go    { color: #888 } // Generic.Output
+  .gp    { color: #555 } // Generic.Prompt
+  .gs    { font-weight: bold } // Generic.Strong
+  .gu    { color: #aaa } // Generic.Subheading
+  .gt    { color: #a00 } // Generic.Traceback
+  .kc    { font-weight: bold } // Keyword.Constant
+  .kd    { font-weight: bold } // Keyword.Declaration
+  .kp    { font-weight: bold } // Keyword.Pseudo
+  .kr    { font-weight: bold } // Keyword.Reserved
+  .kt    { color: #458; font-weight: bold } // Keyword.Type
+  .m     { color: #099 } // Literal.Number
+  .s     { color: #d14 } // Literal.String
+  .na    { color: #008080 } // Name.Attribute
+  .nb    { color: #0086B3 } // Name.Builtin
+  .nc    { color: #458; font-weight: bold } // Name.Class
+  .no    { color: #008080 } // Name.Constant
+  .ni    { color: #800080 } // Name.Entity
+  .ne    { color: #900; font-weight: bold } // Name.Exception
+  .nf    { color: #900; font-weight: bold } // Name.Function
+  .nn    { color: #555 } // Name.Namespace
+  .nt    { color: #000080 } // Name.Tag
+  .nv    { color: #008080 } // Name.Variable
+  .ow    { font-weight: bold } // Operator.Word
+  .w     { color: #bbb } // Text.Whitespace
+  .mf    { color: #099 } // Literal.Number.Float
+  .mh    { color: #099 } // Literal.Number.Hex
+  .mi    { color: #099 } // Literal.Number.Integer
+  .mo    { color: #099 } // Literal.Number.Oct
+  .sb    { color: #d14 } // Literal.String.Backtick
+  .sc    { color: #d14 } // Literal.String.Char
+  .sd    { color: #d14 } // Literal.String.Doc
+  .s2    { color: #d14 } // Literal.String.Double
+  .se    { color: #d14 } // Literal.String.Escape
+  .sh    { color: #d14 } // Literal.String.Heredoc
+  .si    { color: #d14 } // Literal.String.Interpol
+  .sx    { color: #d14 } // Literal.String.Other
+  .sr    { color: #009926 } // Literal.String.Regex
+  .s1    { color: #d14 } // Literal.String.Single
+  .ss    { color: #990073 } // Literal.String.Symbol
+  .bp    { color: #999 } // Name.Builtin.Pseudo
+  .vc    { color: #008080 } // Name.Variable.Class
+  .vg    { color: #008080 } // Name.Variable.Global
+  .vi    { color: #008080 } // Name.Variable.Instance
+  .il    { color: #099 } // Literal.Number.Integer.Long
+}

--- a/packages/components/docs/components/alert.md
+++ b/packages/components/docs/components/alert.md
@@ -1,0 +1,129 @@
+---
+layout: default
+title: Alert
+---
+
+# Alert
+
+An Alert component
+
+selector: `t-alert`
+
+## Default
+
+<div class="demo-container">
+	<t-alert id="alert-without-timeout" opened="true">
+		This is only a warning - for your information!
+	</t-alert>
+</div>
+
+```html
+<t-alert>
+    This is only a warning - for your information!
+</t-alert>
+```
+
+## With Headline
+
+<div class="demo-container">
+	<t-alert headline="Help!" opened="true">
+			This is only a warning - for your information!
+	</t-alert>
+</div>
+
+```html
+<t-alert headline="Help!">
+    This is only a warning - for your information!
+</t-alert>
+```
+
+## Variants
+
+### Danger
+
+<div class="demo-container">
+	<t-alert variant="danger" opened="true">
+			This is only a warning - for your information!
+	</t-alert>
+</div>
+
+```html
+<t-alert variant="danger">
+    This is only a warning - for your information!
+</t-alert>
+```
+
+### Success
+
+<div class="demo-container">
+	<t-alert variant="success" opened="true">
+			This is only a warning - for your information!
+	</t-alert>
+</div>
+
+```html
+<t-alert variant="success">
+    This is only a warning - for your information!
+</t-alert>
+```
+
+## With Default Timeout
+
+<div class="demo-container">
+	<t-button id="show-alert-btn-with-default-timeout">
+		show alert with default timeout
+	</t-button>
+	<t-alert id="alert-with-default-timeout" timeout="true">
+		This is only a warning - for your information!
+	</t-alert>
+</div>
+
+<script>
+	const showAlert = document.querySelector(
+		"#show-alert-btn-with-default-timeout"
+	);
+	const alert = document.getElementById("alert-with-default-timeout");
+	showAlert.addEventListener("click", () => !alert.opened && alert.open());
+</script>
+
+```html
+<t-alert timeout="true">
+    This is only a warning - for your information!
+</t-alert>
+```
+
+## With Custom Timeout
+
+<div class="demo-container">
+	<t-button id="show-alert-btn-with-custom-timeout">
+		show alert with custom timeout
+	</t-button>
+	<t-alert id="alert-with-custom-timeout" timeout="500">
+		This is only a warning - for your information!
+	</t-alert>
+</div>
+
+<script>
+	const showAlertWithCustom = document.querySelector(
+		"#show-alert-btn-with-custom-timeout"
+	);
+	const alertWithCustom = document.getElementById(
+		"alert-with-custom-timeout"
+	);
+	showAlertWithCustom.addEventListener(
+		"click",
+		() => !alertWithCustom.opened && alertWithCustom.open()
+	);
+</script>
+
+```html
+<t-alert timeout="500">
+    This is only a warning - for your information!
+</t-alert>
+```
+```javascript
+const showAlertWithCustom = document.querySelector("#show-alert-btn-with-custom-timeout");
+const alertWithCustom = document.getElementById("alert-with-custom-timeout");
+
+showAlertWithCustom.addEventListener("click", () => !alertWithCustom.opened && alertWithCustom.open());
+```

--- a/packages/components/docs/components/button.md
+++ b/packages/components/docs/components/button.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Button
+---
+
+# Button
+
+A Button component
+
+selector: `t-button`
+
+## Default
+
+```html
+<t-button>Label</t-button>
+```
+
+<div class="demo-container">
+  <t-button>Label</t-button>
+</div>
+
+## Disabled
+
+```html
+<t-button disabled="true">Label</t-button>
+```
+
+<div class="demo-container">
+  <t-button disabled="true">Label</t-button>
+</div>

--- a/packages/components/docs/components/card.md
+++ b/packages/components/docs/components/card.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Card
+---
+
+# Card
+
+A Card component
+
+selector: `t-card`
+
+## Default
+<div class="demo-container">
+	<t-card>Card content</t-card>
+</div>
+
+```html
+<t-card>Card content</t-card>
+```
+
+## With Header
+<div class="demo-container">
+	<t-card>
+		<h3 slot="header">Header content</h3>
+		Card content
+	</t-card>
+</div>
+
+```html
+<t-card>
+  <h3 slot="header">Header content</h3>
+  Card content
+</t-card>
+```
+
+## With Footer
+<div class="demo-container">
+	<t-card>
+		Card content
+		<h3 slot="footer">Footer content</h3>
+	</t-card>
+</div>
+
+```html
+<t-card>
+  Card content
+  <h3 slot="footer">Footer content</h3>
+</t-card>
+```
+
+## With Image
+<div class="demo-container">
+	<t-card image-top="http://placehold.it/400x300" image-top-alt="Image alt text">
+	Card content
+	</t-card>
+</div>
+
+```html
+<t-card image-top="http://placehold.it/400x300" image-top-alt="Image alt text">
+  Card content
+</t-card>
+```

--- a/packages/components/docs/index.md
+++ b/packages/components/docs/index.md
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Home
+exclude: true
+---
+
+# Telements

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -23,12 +23,17 @@
     "pretest": "yarn test-install-hack:add",
     "posttest": "yarn test-install-hack:remove",
     "test": "stencil test --spec --e2e",
-    "test.watch": "stencil test --spec --e2e --watchAll"
+    "test.watch": "stencil test --spec --e2e --watchAll",
+    "docs": "cd ./docs && jekyll serve",
+    "watch:build": "node ./scripts/watch-build.js",
+    "start:docs": "sd concurrent \"yarn watch:build\" \"yarn docs\""
   },
   "devDependencies": {
     "@stencil/core": "1.0.5",
+    "@stencil/utils": "0.0.5",
     "@types/jest": "24.0.15",
     "@types/puppeteer": "1.12.4",
+    "chokidar": "^3.2.2",
     "jest": "24.8.0",
     "jest-cli": "24.8.0",
     "puppeteer": "1.17.0"

--- a/packages/components/scripts/watch-build.js
+++ b/packages/components/scripts/watch-build.js
@@ -1,0 +1,22 @@
+var chokidar = require('chokidar');
+const shell = require('child_process').execSync;
+
+// TODO: This is the 'watch' mode, sync dist folder after `build` command is executed
+const build= `./www/build`;
+const dist= `./docs/dist`;
+
+var watcher = chokidar.watch(build, {ignored: /^\./, persistent: true});
+
+// TODO: optimise so only affected files are copied, currently
+// on every file change the whole folder ist being copied
+function copyDistFolder(action, fileName) {
+  console.log(action, fileName)
+	shell(`mkdir -p ${dist}`);
+	shell(`cp -r ${build}/* ${dist}`);
+}
+
+watcher
+  .on('add', (fileName) => copyDistFolder('add', fileName))
+  .on('change', (fileName) => copyDistFolder('change', fileName))
+  .on('remove', (fileName) => copyDistFolder('remove', fileName))
+  .on('error', (fileName) => console.log('error', fileName))

--- a/yarn.lock
+++ b/yarn.lock
@@ -292,6 +292,11 @@
   dependencies:
     typescript "3.5.2"
 
+"@stencil/utils@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@stencil/utils/-/utils-0.0.5.tgz#c49577d932d6289ae082c50135ca10f496da8991"
+  integrity sha512-YOmrMgSTzGZtC2hSrD7vXWIerhEcxzUu+pdKQ2wev4QO8O++WR1lZydFTfFgsA+NSCn6RYzPmhbGOrs9+PBw6Q==
+
 "@types/babel__core@^7.1.0":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.2.tgz#608c74f55928033fce18b99b213c16be4b3d114f"
@@ -481,6 +486,14 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -646,6 +659,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
+  integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
+
 bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
@@ -677,6 +695,13 @@ braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+braces@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 browser-process-hrtime@^0.1.2:
   version "0.1.3"
@@ -778,6 +803,21 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chokidar@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.2.2.tgz#a433973350021e09f2b853a2287781022c0dc935"
+  integrity sha512-bw3pm7kZ2Wa6+jQWYP/c7bAZy3i4GwiIiMO2EeRjrE48l8vBqC/WvFhSF0xyM8fQiPEGvwMY/5bqDG7sSEOuhg==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.2.0"
+  optionalDependencies:
+    fsevents "~2.1.1"
 
 chownr@^1.1.1:
   version "1.1.2"
@@ -1378,6 +1418,13 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -1454,6 +1501,11 @@ fsevents@^1.2.7:
     nan "^2.12.1"
     node-pre-gyp "^0.12.0"
 
+fsevents@~2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.1.tgz#74c64e21df71721845d0c44fe54b7f56b82995a9"
+  integrity sha512-4FRPXWETxtigtJW/gxzEDsX1LVbPAM93VleB83kZB+ellqbHMkyt2aJfuzNLRvFPnGi6bcE5SvfxgbXPeKteJw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -1504,6 +1556,13 @@ getpass@^0.1.1:
   integrity sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
   dependencies:
     assert-plus "^1.0.0"
+
+glob-parent@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.0.tgz#5f4c1d1e748d30cd73ad2944b3577a81b081e8c2"
+  integrity sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.4"
@@ -1740,6 +1799,13 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -1806,6 +1872,11 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -1823,6 +1894,13 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
+is-glob@^4.0.1, is-glob@~4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
 is-natural-number@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
@@ -1834,6 +1912,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -2808,6 +2891,11 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-path@^3.0.0, normalize-path@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 npm-bundled@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.6.tgz#e7ba9aadcef962bb61248f91721cd932b3fe6bdd"
@@ -3064,6 +3152,11 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
+picomatch@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.0.7.tgz#514169d8c7cd0bdbeecc8a2609e34a7163de69f6"
+  integrity sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -3249,6 +3342,13 @@ readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.2.2, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readdirp@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.2.0.tgz#c30c33352b12c96dfb4b895421a49fd5a9593839"
+  integrity sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==
+  dependencies:
+    picomatch "^2.0.4"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -3835,6 +3935,13 @@ to-regex-range@^2.1.0:
   dependencies:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
+
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
 
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
#51 - As `Storybook` seems to be currently quite limited with web-components support, this is an alternative solution to get started.

This pull request provides a simple static `jekyll` website with markdown pages for component documentation

To get up and running with `jekyll` please refer to their `docs` page: https://jekyllrb.com/docs/

Once you have the `Ruby development environment` and `bundler` installed you can start the docs by running `yarn start:docs` command, the website will be running at port 4000